### PR TITLE
feat: Use locals in the imports file

### DIFF
--- a/.local/bin/get_ids.sh
+++ b/.local/bin/get_ids.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+tf_token="<HCP_TERRAFORM_API_TOKEN>"
+organization_name="<HCP_TERRAFORM_ORGANIZATION_NAME>"
+
+# The owners team ID is used in the organization membership ID query, so
+# we assign it to a variable.
+owners_team_id="$(
+  curl --silent \
+    --header "Authorization: Bearer ${tf_token}" \
+    --header "Content-Type: application/vnd.api+json" \
+    https://app.terraform.io/api/v2/organizations/"${organization_name}"/teams |
+    jq -r '.data[] | select(.attributes.name == "owners") | .id'
+)"
+
+# Display the owners team ID.
+printf '%s\n' "Team ID               Team Name"
+printf '%s\n' "--------------------- ---------"
+printf '%s %s\n\n' "${owners_team_id}" "owners"
+
+# Display the organization membership IDs.
+printf '%s\n' "Org Membership ID   Username"
+printf '%s\n' "------------------- ----------------------------------------"
+curl --silent \
+  --header "Authorization: Bearer ${tf_token}" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/teams/"${owners_team_id}" |
+  jq -r '.data.relationships."organization-memberships".data[].id' |
+  while read -r organization_membership_id; do
+    curl --silent \
+      --header "Authorization: Bearer ${tf_token}" \
+      --header "Content-Type: application/vnd.api+json" \
+      https://app.terraform.io/api/v2/organization-memberships/"${organization_membership_id}" |
+      jq -r '.data.relationships.user.data.id' |
+      while read -r user_id; do
+        username="$(curl --silent \
+          --header "Authorization: Bearer ${tf_token}" \
+          --header "Content-Type: application/vnd.api+json" \
+          https://app.terraform.io/api/v2/users/"${user_id}" |
+          jq -r '.data.attributes.username')"
+        printf '%s %s\n' "${organization_membership_id}" "${username}"
+      done
+  done
+
+# Display the variable set IDs.
+printf '\n%s\n' "Variable Set ID         Variable Set Name"
+printf '%s\n' "----------------------- ---------------------------"
+curl --silent \
+  --header "Authorization: Bearer ${tf_token}" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/organizations/"${organization_name}"/varsets |
+  jq -r '.data[].id' |
+  while read -r variable_set_id; do
+    variable_set_name="$(curl --silent \
+      --header "Authorization: Bearer ${tf_token}" \
+      --header "Content-Type: application/vnd.api+json" \
+      https://app.terraform.io/api/v2/varsets/"${variable_set_id}" |
+      jq -r '.data.attributes.name')"
+    printf '%s %s\n' "${variable_set_id}" "${variable_set_name}"
+  done
+
+# Display the project IDs.
+printf '\n%s\n' "Project ID           Project Name"
+printf '%s\n' "-------------------- ---------------"
+curl --silent \
+  --header "Authorization: Bearer ${tf_token}" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/organizations/"${organization_name}"/projects |
+  jq -r '.data[].id' |
+  while read -r project_id; do
+    project_name="$(curl --silent \
+      --header "Authorization: Bearer ${tf_token}" \
+      --header "Content-Type: application/vnd.api+json" \
+      https://app.terraform.io/api/v2/projects/"${project_id}" |
+      jq -r '.data.attributes.name')"
+    printf '%s %s\n' "${project_id}" "${project_name}"
+  done
+
+# Display the workspace IDs.
+printf '\n%s\n' "Workspace ID        Workspace Name"
+printf '%s\n' "------------------- -------------------"
+curl --silent \
+  --header "Authorization: Bearer ${tf_token}" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/organizations/"${organization_name}"/workspaces |
+  jq -r '.data[].id' |
+  while read -r workspace_id; do
+    workspace_name="$(curl --silent \
+      --header "Authorization: Bearer ${tf_token}" \
+      --header "Content-Type: application/vnd.api+json" \
+      https://app.terraform.io/api/v2/workspaces/"${workspace_id}" |
+      jq -r '.data.attributes.name')"
+    printf '%s %s\n' "${workspace_id}" "${workspace_name}"
+  done

--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ No modules.
 | [tfe_variable_set.tfe_provider_authentication](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/variable_set) | resource |
 | [tfe_workspace.hcp_terraform_admin](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace) | resource |
 | [tfe_workspace_variable_set.tfe_provider_authentication](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace_variable_set) | resource |
-| [tfe_organization_membership.api_org](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
-| [tfe_organization_membership.api_team](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
 | [tfe_organization_membership.doormat](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
-| [tfe_organization_membership.gh_webhooks](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
 | [tfe_organization_membership.owner](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
 | [tfe_team.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/team) | data source |
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,21 @@ The following steps must be taken before being able to run the code in this repo
 ### HCP Terraform
 
 1. Create an HCP Terraform organization.
-2. Generate a user API token to authenticate with HCP Terraform.
-3. Run `terraform init` in this repository to create the backend workspace.
-4. Generate a team API token for the "owners" team.
-5. Create a variable set named "TFE Provider Authentication".
+2. Run `terraform login` to generate a user API token.
+3. Run `terraform init` to create the backend workspace.
+4. Manually generate a team API token for the "owners" team.
+5. Manually create a variable set named "TFE Provider Authentication".
 6. Populate the variable set with the `TFE_TOKEN` environment variable, using the API token as the (sensitive) value.
-7. Assign the variable set to the new workspace.
-8. Update `imports.tf` with the ID of the resources in your HCP Terraform organization.
-9. Update `locals.tf` with the ID of the resources in your HCP Terraform organization.
+7. Assign the variable set to the backend workspace.
+8. Update `locals.tf` with the ID of the resources in your HCP Terraform organization.
+
+#### Populate `locals.tf`
+
+To get a list of the relevant IDs needed to populate `locals.tf`, review and 
+run the script in [`.local/bin/get_ids.sh`](.local/bin/get_ids.sh).
+
+> [!NOTE]  
+> The `get_ids.sh` script requires that [`jq(1)`](https://jqlang.github.io/jq/) be installed.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/imports.tf
+++ b/imports.tf
@@ -1,36 +1,34 @@
-# When migrating this code base to a new organization, these IDs will need to be updated.
-
 import {
-  id = "craigsloggett-lab" # Organizations can only be imported by name.
+  id = var.hcp_terraform_organization_name # Organizations can only be imported by name.
   to = tfe_organization.this
 }
 
 import {
-  id = "team-p9ryLNrpQ9TNmEFh"
+  id = local.owners_team_id
   to = tfe_team_organization_members.owners
 }
 
 import {
-  id = "prj-1ifijXyay7xeH9Zc"
+  id = local.default_project_id
   to = tfe_project.default
 }
 
 import {
-  id = "prj-qW7NitPW1R49WN4b"
-  to = tfe_project.platform_team
-}
-
-import {
-  id = "varset-FwFGK65suTr7eaAA"
+  id = local.tfe_provider_authentication_variable_set_id
   to = tfe_variable_set.tfe_provider_authentication
 }
 
 import {
-  id = "craigsloggett-lab/hcp-terraform-admin/TFE Provider Authentication"
+  id = local.tfe_provider_authentication_workspace_variable_set_id
   to = tfe_workspace_variable_set.tfe_provider_authentication
 }
 
 import {
-  id = "ws-aAUcuGF6QEJKuQyL"
+  id = local.hcp_platform_team_project_id
+  to = tfe_project.platform_team
+}
+
+import {
+  id = local.hcp_terraform_admin_workspace_id
   to = tfe_workspace.hcp_terraform_admin
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,10 +1,19 @@
 locals {
-  organization_membership_ids = {
-    # Hidden internal users for HashiCorp's systems.
+  owners_team_id     = "team-p9ryLNrpQ9TNmEFh"
+  default_project_id = "prj-1ifijXyay7xeH9Zc"
+
+  # The TFE Provider Authentication variable set.
+  tfe_provider_authentication_variable_set_id           = "varset-FwFGK65suTr7eaAA"
+  tfe_provider_authentication_workspace_variable_set_id = "craigsloggett-lab/hcp-terraform-admin/TFE Provider Authentication"
+
+  # The resources defined in `backend.tf`.
+  hcp_terraform_admin_workspace_id = "ws-aAUcuGF6QEJKuQyL"
+  hcp_platform_team_project_id     = "prj-qW7NitPW1R49WN4b"
+
+  # Hidden users for HashiCorp's internal systems.
+  hidden_users_organization_membership_ids = {
     api_org     = "ou-EhS6WkPBDVPxYYqd"
     api_team    = "ou-mLy6EZTkP2bKW9w3"
     gh_webhooks = "ou-j7QUTL6CcJUktJJC"
-    # Doormat is the service used to manage HCP Terraform organizations for HashiCorp employees.
-    doormat = "ou-9KRr8gq4h6JikktE"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,10 +10,10 @@ variable "hcp_terraform_organization_email" {
   default     = "craig.sloggett@hashicorp.com"
 }
 
-variable "hcp_terraform_admins_team_name" {
+variable "hcp_terraform_admin_workspace_name" {
   type        = string
-  description = "The name of the team of users who administer the HCP Terraform organization."
-  default     = "admins"
+  description = "The name of the workspace used to manage this HCP Terraform organization."
+  default     = "hcp-terraform-admin"
 }
 
 variable "hcp_platform_team_project_name" {
@@ -22,10 +22,10 @@ variable "hcp_platform_team_project_name" {
   default     = "Platform Team"
 }
 
-variable "hcp_terraform_admin_workspace_name" {
+variable "hcp_terraform_admins_team_name" {
   type        = string
-  description = "The name of the workspace used to manage this HCP Terraform organization."
-  default     = "hcp-terraform-admin"
+  description = "The name of the team of users who administer the HCP Terraform organization."
+  default     = "admins"
 }
 
 variable "terraform_version" {


### PR DESCRIPTION
To reduce the number of files a user would need to update when bootstrapping the environment, `locals` are used to reference IDs in the `import` blocks. A convenience script has been added to easily grab the relevant IDs after the manual steps have been completed as outlined in the README.