### PR TITLE
chore: Clearly separate post bootstrap resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ No modules.
 |------|------|
 | [tfe_organization.this](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/organization) | resource |
 | [tfe_organization_membership.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/organization_membership) | resource |
+| [tfe_project.backend](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/project) | resource |
 | [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/project) | resource |
-| [tfe_project.platform_team](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/project) | resource |
 | [tfe_team.admins](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/team) | resource |
 | [tfe_team.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/team) | resource |
 | [tfe_team_organization_members.admins](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/team_organization_members) | resource |
 | [tfe_team_organization_members.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/team_organization_members) | resource |
 | [tfe_team_project_access.admins](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/team_project_access) | resource |
 | [tfe_variable_set.tfe_provider_authentication](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/variable_set) | resource |
-| [tfe_workspace.hcp_terraform_admin](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace) | resource |
-| [tfe_workspace_variable_set.tfe_provider_authentication](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace_variable_set) | resource |
+| [tfe_workspace.backend](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace) | resource |
+| [tfe_workspace_variable_set.backend](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/resources/workspace_variable_set) | resource |
 | [tfe_organization_membership.admins](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/organization_membership) | data source |
 | [tfe_registry_gpg_keys.all](https://registry.terraform.io/providers/hashicorp/tfe/0.62.0/docs/data-sources/registry_gpg_keys) | data source |
 
@@ -78,14 +78,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admins_team_emails"></a> [admins\_team\_emails](#input\_admins\_team\_emails) | A list of member email addresses for the admins team. | `set(string)` | `[]` | no |
-| <a name="input_hcp_platform_team_project_name"></a> [hcp\_platform\_team\_project\_name](#input\_hcp\_platform\_team\_project\_name) | The name of the project used to manage HashiCorp Cloud Platform services. | `string` | `"Platform Team"` | no |
-| <a name="input_hcp_terraform_admin_workspace_name"></a> [hcp\_terraform\_admin\_workspace\_name](#input\_hcp\_terraform\_admin\_workspace\_name) | The name of the workspace used to manage this HCP Terraform organization. | `string` | `"hcp-terraform-admin"` | no |
+| <a name="input_backend_project_name"></a> [backend\_project\_name](#input\_backend\_project\_name) | The name of the project used to manage this HCP Terraform organization. | `string` | n/a | yes |
+| <a name="input_backend_workspace_name"></a> [backend\_workspace\_name](#input\_backend\_workspace\_name) | The name of the workspace used to manage this HCP Terraform organization. | `string` | n/a | yes |
 | <a name="input_hcp_terraform_admins_team_name"></a> [hcp\_terraform\_admins\_team\_name](#input\_hcp\_terraform\_admins\_team\_name) | The name of the team of users who administer the HCP Terraform organization. | `string` | `"admins"` | no |
 | <a name="input_hcp_terraform_organization_email"></a> [hcp\_terraform\_organization\_email](#input\_hcp\_terraform\_organization\_email) | The notification email address for the HCP Terraform organization being managed. | `string` | n/a | yes |
 | <a name="input_hcp_terraform_organization_name"></a> [hcp\_terraform\_organization\_name](#input\_hcp\_terraform\_organization\_name) | The name of the HCP Terraform organization being managed. | `string` | n/a | yes |
 | <a name="input_owners_team_emails"></a> [owners\_team\_emails](#input\_owners\_team\_emails) | A list of member email addresses for the owners team. | `set(string)` | `[]` | no |
 | <a name="input_terraform_version"></a> [terraform\_version](#input\_terraform\_version) | The version of Terraform to use in all workspaces. | `string` | `"1.10.3"` | no |
-| <a name="input_tfe_provider_authentication_variable_set_name"></a> [tfe\_provider\_authentication\_variable\_set\_name](#input\_tfe\_provider\_authentication\_variable\_set\_name) | The name of the variable set used to offer authentication to the TFE provider. | `string` | `"TFE Provider Authentication"` | no |
+| <a name="input_tfe_provider_authentication_variable_set_name"></a> [tfe\_provider\_authentication\_variable\_set\_name](#input\_tfe\_provider\_authentication\_variable\_set\_name) | The name of the variable set used to authenticate the TFE provider. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/backend.tf
+++ b/backend.tf
@@ -3,8 +3,8 @@ terraform {
     organization = "craigsloggett-lab" # Update the `hcp_terraform_organization_name` variable to match.
 
     workspaces {
-      name    = "hcp-terraform-admin" # Update the `hcp_terraform_owners_workspace_name` variable to match.
-      project = "Platform Team"       # Update the `hcp_platform_team_project_name` variable to match.
+      project = "Platform Team"       # Update the `backend_project_name` variable to match.
+      name    = "hcp-terraform-admin" # Update the `backend_workspace_name` variable to match.
     }
   }
 }

--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -1,0 +1,56 @@
+resource "tfe_organization" "this" {
+  name  = var.hcp_terraform_organization_name
+  email = var.hcp_terraform_organization_email
+
+  assessments_enforced = true
+}
+
+resource "tfe_team" "owners" {
+  name         = "owners"
+  organization = tfe_organization.this.name
+}
+
+resource "tfe_organization_membership" "owners" {
+  for_each     = local.owners_team_emails
+  organization = tfe_organization.this.name
+  email        = each.value
+}
+
+resource "tfe_team_organization_members" "owners" {
+  team_id = tfe_team.owners.id
+  organization_membership_ids = [
+    for email in local.owners_team_emails : tfe_organization_membership.owners[email].id
+  ]
+}
+
+resource "tfe_project" "default" {
+  name         = "Default Project"
+  organization = tfe_organization.this.name
+  description  = "The default project for new workspaces."
+}
+
+resource "tfe_project" "backend" {
+  name         = var.backend_project_name
+  organization = tfe_organization.this.name
+  description  = "A collection of workspaces to manage platform services."
+}
+
+resource "tfe_workspace" "backend" {
+  name         = var.backend_workspace_name
+  organization = tfe_organization.this.name
+  project_id   = tfe_project.backend.id
+
+  terraform_version = var.terraform_version
+  queue_all_runs    = false
+}
+
+resource "tfe_variable_set" "tfe_provider_authentication" {
+  name         = var.tfe_provider_authentication_variable_set_name
+  description  = "The token used to authenticate the TFE provider for managing this HCP Terraform organization."
+  organization = tfe_organization.this.name
+}
+
+resource "tfe_workspace_variable_set" "backend" {
+  workspace_id    = tfe_workspace.backend.id
+  variable_set_id = tfe_variable_set.tfe_provider_authentication.id
+}

--- a/imports.tf
+++ b/imports.tf
@@ -1,6 +1,6 @@
-# The HCP Terraform organization.
+# The HCP Terraform organization under management.
 import {
-  id = var.hcp_terraform_organization_name # Organizations can only be imported by name.
+  id = var.hcp_terraform_organization_name
   to = tfe_organization.this
 }
 
@@ -10,42 +10,43 @@ import {
   to = tfe_team.owners
 }
 
+# The organization membership of each user that comes with the HCP Terraform 
+# organization. These users are all placed in the `owners` team by default.
+import {
+  for_each = local.imports.organization_membership_ids.owners
+  id       = each.value
+  to       = tfe_organization_membership.owners[each.key]
+}
+
 # The `owners` team members.
 import {
   id = tfe_team.owners.id
   to = tfe_team_organization_members.owners
 }
 
-# The organization membership of each user that comes with the HCP Terraform organization.
-# These users are all placed in the `owners` team by default.
-import {
-  for_each = local.imports.organization_membership_ids
-  id       = each.value
-  to       = tfe_organization_membership.owners[each.key]
-}
-
 # The `Default Project` project.
 import {
-  id = local.imports.project_ids.default_project
+  id = local.imports.project_ids["Default Project"]
   to = tfe_project.default
 }
 
 # The project that is configured in `backend.tf`.
 import {
-  id = local.imports.project_ids.platform_team
-  to = tfe_project.platform_team
+  id = local.imports.project_ids[var.backend_project_name]
+  to = tfe_project.backend
 }
 
 # The workspace that is configured in `backend.tf`.
 import {
-  id = local.imports.workspace_ids.hcp_terraform_admin
-  to = tfe_workspace.hcp_terraform_admin
+  id = local.imports.workspace_ids[var.backend_workspace_name]
+  to = tfe_workspace.backend
 }
 
 # The `TFE Provider Authentication` variable set. 
-# This contains the `TFE_TOKEN` for managing this organization in the workspace configured in `backend.tf`.
+# This contains the `TFE_TOKEN` environment variable used to authenticate the
+# TFE provider.
 import {
-  id = local.imports.variable_set_ids.tfe_provider_authentication
+  id = local.imports.variable_set_ids[var.tfe_provider_authentication_variable_set_name]
   to = tfe_variable_set.tfe_provider_authentication
 }
 
@@ -53,8 +54,8 @@ import {
 import {
   id = join("/", [
     var.hcp_terraform_organization_name,
-    tfe_workspace.hcp_terraform_admin.name,
+    tfe_workspace.backend.name,
     var.tfe_provider_authentication_variable_set_name,
   ])
-  to = tfe_workspace_variable_set.tfe_provider_authentication
+  to = tfe_workspace_variable_set.backend
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,11 @@
 locals {
-  # The `owners_team_emails` local variable combines user-provided email 
-  # addresses from `var.owners_team_emails` with the default organization 
-  # membership emails from `local.imports.organization_membership_ids`. This 
-  # ensures that both manually added and system-defined owners are included 
-  # without duplicates, as the setunion guarantees uniqueness.
+  # The `owners_team_emails` local variable combines user-provided email
+  # addresses from `var.owners_team_emails` with the default organization
+  # membership emails from `local.imports.organization_membership_ids.owners`.
+  # The setunion() function guarantees that both manually added and 
+  # system-defined owners are included without duplicates.
   owners_team_emails = toset(setunion(
-    keys(local.imports.organization_membership_ids),
+    keys(local.imports.organization_membership_ids.owners),
     var.owners_team_emails,
   ))
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,0 @@
-resource "tfe_organization" "this" {
-  name  = var.hcp_terraform_organization_name
-  email = var.hcp_terraform_organization_email
-
-  assessments_enforced = true
-}

--- a/projects.tf
+++ b/projects.tf
@@ -1,11 +1,2 @@
-resource "tfe_project" "default" {
-  name         = "Default Project"
-  organization = tfe_organization.this.name
-  description  = "The default project for new workspaces."
-}
-
-resource "tfe_project" "platform_team" {
-  name         = var.hcp_platform_team_project_name
-  organization = tfe_organization.this.name
-  description  = "A collection of workspaces to manage HashiCorp Cloud Platform services."
-}
+# The resources for the project configured in `backend.tf` can be found in `bootstrap.tf`.
+# The resources for the Default Project can be found in `bootstrap.tf`.

--- a/teams.tf
+++ b/teams.tf
@@ -1,20 +1,4 @@
-resource "tfe_team" "owners" {
-  name         = "owners"
-  organization = tfe_organization.this.name
-}
-
-resource "tfe_organization_membership" "owners" {
-  for_each     = local.owners_team_emails
-  organization = tfe_organization.this.name
-  email        = each.value
-}
-
-resource "tfe_team_organization_members" "owners" {
-  team_id = tfe_team.owners.id
-  organization_membership_ids = [
-    for email in local.owners_team_emails : tfe_organization_membership.owners[email].id
-  ]
-}
+# The `owners` team resources can be found in `bootstrap.tf`.
 
 resource "tfe_team" "admins" {
   name         = var.hcp_terraform_admins_team_name
@@ -51,8 +35,9 @@ resource "tfe_team_organization_members" "admins" {
   organization_membership_ids = [for email in var.admins_team_emails : data.tfe_organization_membership.admins[email].id]
 }
 
+# Provide admin access to the project configured in `backend.tf`.
 resource "tfe_team_project_access" "admins" {
   access     = "admin"
   team_id    = tfe_team.admins.id
-  project_id = tfe_project.platform_team.id
+  project_id = tfe_project.backend.id
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,17 +1,18 @@
 # Required
-hcp_terraform_organization_name  = "craigsloggett-lab"
-hcp_terraform_organization_email = "craig.sloggett@hashicorp.com"
+hcp_terraform_organization_name               = "craigsloggett-lab"
+hcp_terraform_organization_email              = "craig.sloggett@hashicorp.com"
+backend_project_name                          = "Platform Team"
+backend_workspace_name                        = "hcp-terraform-admin"
+tfe_provider_authentication_variable_set_name = "TFE Provider Authentication"
 
 # Optional
-hcp_terraform_admin_workspace_name            = "hcp-terraform-admin"
-hcp_platform_team_project_name                = "Platform Team"
-tfe_provider_authentication_variable_set_name = "TFE Provider Authentication"
-hcp_terraform_admins_team_name                = "admins"
-terraform_version                             = "1.10.3"
+terraform_version = "1.10.3"
 
 owners_team_emails = [
   "craig.sloggett@hashicorp.com",
 ]
+
+hcp_terraform_admins_team_name = "admins"
 
 admins_team_emails = [
   "craig.sloggett@hashicorp.com",

--- a/variable_sets.tf
+++ b/variable_sets.tf
@@ -1,10 +1,1 @@
-resource "tfe_variable_set" "tfe_provider_authentication" {
-  name         = var.tfe_provider_authentication_variable_set_name
-  description  = "The token used to authenticate the TFE provider for managing this HCP Terraform organization."
-  organization = tfe_organization.this.name
-}
-
-resource "tfe_workspace_variable_set" "tfe_provider_authentication" {
-  workspace_id    = tfe_workspace.hcp_terraform_admin.id
-  variable_set_id = tfe_variable_set.tfe_provider_authentication.id
-}
+# The resources for the variable set containing authentication for the TFE provider can be found in `bootstrap.tf`.

--- a/variables.tf
+++ b/variables.tf
@@ -8,22 +8,25 @@ variable "hcp_terraform_organization_email" {
   description = "The notification email address for the HCP Terraform organization being managed."
 }
 
-variable "hcp_terraform_admin_workspace_name" {
+variable "backend_project_name" {
   type        = string
-  description = "The name of the workspace used to manage this HCP Terraform organization."
-  default     = "hcp-terraform-admin"
+  description = "The name of the project used to manage this HCP Terraform organization."
 }
 
-variable "hcp_platform_team_project_name" {
+variable "backend_workspace_name" {
   type        = string
-  description = "The name of the project used to manage HashiCorp Cloud Platform services."
-  default     = "Platform Team"
+  description = "The name of the workspace used to manage this HCP Terraform organization."
 }
 
 variable "tfe_provider_authentication_variable_set_name" {
   type        = string
-  description = "The name of the variable set used to offer authentication to the TFE provider."
-  default     = "TFE Provider Authentication"
+  description = "The name of the variable set used to authenticate the TFE provider."
+}
+
+variable "terraform_version" {
+  type        = string
+  description = "The version of Terraform to use in all workspaces."
+  default     = "1.10.3"
 }
 
 variable "owners_team_emails" {
@@ -42,10 +45,4 @@ variable "admins_team_emails" {
   description = "A list of member email addresses for the admins team."
   type        = set(string)
   default     = []
-}
-
-variable "terraform_version" {
-  type        = string
-  description = "The version of Terraform to use in all workspaces."
-  default     = "1.10.3"
 }

--- a/workspaces.tf
+++ b/workspaces.tf
@@ -1,8 +1,1 @@
-resource "tfe_workspace" "hcp_terraform_admin" {
-  name         = var.hcp_terraform_admin_workspace_name
-  organization = tfe_organization.this.name
-  project_id   = tfe_project.platform_team.id
-
-  terraform_version = var.terraform_version
-  queue_all_runs    = false
-}
+# The resources for the workspace configured in `backend.tf` can be found in `bootstrap.tf`.


### PR DESCRIPTION
Put the resources that come with an HCP Terraform organization into their own `bootstrap.tf` file to clearly show which resources are added post bootstrap. The workspace and project resources that are configured in `backend.tf` have been renamed to be more generic (`tfe_project.backend`) while giving the user an option to change this with input variables.