### PR TITLE
fix: Filter service accounts when generating locals

### DIFF
--- a/imports.tf
+++ b/imports.tf
@@ -10,7 +10,7 @@ import {
   to = tfe_team.owners
 }
 
-# The organization membership of each user that comes with the HCP Terraform 
+# The organization membership of each user that comes with the HCP Terraform
 # organization. These users are all placed in the `owners` team by default.
 import {
   for_each = local.imports.organization_membership_ids.owners
@@ -42,7 +42,7 @@ import {
   to = tfe_workspace.backend
 }
 
-# The `TFE Provider Authentication` variable set. 
+# The `TFE Provider Authentication` variable set.
 # This contains the `TFE_TOKEN` environment variable used to authenticate the
 # TFE provider.
 import {

--- a/locals_imports.tf
+++ b/locals_imports.tf
@@ -10,12 +10,8 @@ locals {
     }
     organization_membership_ids = {
       owners = {
-        "craig.sloggett@hashicorp.com"                                     = "ou-tSVPjvXHB4iTqcPb"
-        "doormat@hashicorp.com"                                            = "ou-9KRr8gq4h6JikktE"
-        "api-org-craigsloggett-lab-xqsus22ynh@hashicorp.com"               = "ou-EhS6WkPBDVPxYYqd"
-        "api-team_1202828@hashicorp.com"                                   = "ou-mLy6EZTkP2bKW9w3"
-        "gh-webhooks-craigsloggett-lab-db12onjulf@hashicorp.com"           = "ou-j7QUTL6CcJUktJJC"
-        "auto-run-cancellation-craigsloggett-lab-hc4myy8g8d@hashicorp.com" = "ou-UoaqXuzXho14SSwo"
+        "craig.sloggett@hashicorp.com" = "ou-tSVPjvXHB4iTqcPb"
+        "doormat@hashicorp.com"        = "ou-9KRr8gq4h6JikktE"
       }
     }
     project_ids = {

--- a/scripts/generate_locals_imports.sh
+++ b/scripts/generate_locals_imports.sh
@@ -163,11 +163,18 @@ main() {
     curl "$@" https://app.terraform.io/api/v2/teams/"${owners_team_id}" |
       jq -r '.data.relationships."organization-memberships".data[].id' |
       while read -r organization_membership_id; do
+        user_id="$(
+          curl "$@" https://app.terraform.io/api/v2/organization-memberships/"${organization_membership_id}" |
+            jq -r '.data.relationships.user.data.id'
+        )"
         email="$(
           curl "$@" https://app.terraform.io/api/v2/organization-memberships/"${organization_membership_id}" |
             jq -r '.data.attributes.email'
         )"
-        print_attribute "${email}" "${organization_membership_id}"
+        if ! curl "$@" "https://app.terraform.io/api/v2/users/${user_id}" |
+          jq -e '.data.attributes."is-service-account"' >/dev/null; then
+          print_attribute "${email}" "${organization_membership_id}"
+        fi
       done
   )"
 


### PR DESCRIPTION
The latest version of the TFE provider (`v0.71.0`) filters service accounts in the `tfe_team_organization_members` resource so they are being filtered in the import script to match this behaviour.