### PR TITLE
fix: Discover resources if no organization is configured for the provider

### DIFF
--- a/discovery.tf
+++ b/discovery.tf
@@ -9,8 +9,9 @@ data "external" "variable_set_names" {
 }
 
 data "tfe_variable_set" "this" {
-  for_each = local.variable_set_names
-  name     = each.key
+  for_each     = local.variable_set_names
+  name         = each.key
+  organization = data.tfe_organization.this.name
 }
 
 data "tfe_variables" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,6 @@
+# This file contains all of the resources included in a new HCP Terraform
+# organization. Additional resources are "discovered" in `discovery.tf`.
+
 data "tfe_organizations" "this" {}
 
 data "tfe_organization" "this" {


### PR DESCRIPTION
This fixes the case where no `organization` argument is passed to the `tfe` provider block.

Before this fix, users with the following configuration would see the subsequent error message:

```hcl
provider "tfe" {}
```

```shell
│ Error: no organization was specified on the resource or provider
│
│   with module.discovery.data.tfe_variable_set.this["<VARIABLE_SET_NAME>"],
│   on .terraform/modules/discovery/discovery.tf line 11, in data "tfe_variable_set" "this":
│   11: data "tfe_variable_set" "this" {
```

This requires users to supply the `organization` argument to the provider which isn't robust for a good user experience.