### PR TITLE
feat: Add tfe_project_variable_set discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ No inputs.
 | <a name="output_tfe_organization"></a> [tfe\_organization](#output\_tfe\_organization) | A map of the HCP Terraform organizations details including 'id' and 'name'. Only inludes 'this' organization. |
 | <a name="output_tfe_organization_membership"></a> [tfe\_organization\_membership](#output\_tfe\_organization\_membership) | A list containing details about the HCP Terraform organization members. |
 | <a name="output_tfe_project"></a> [tfe\_project](#output\_tfe\_project) | A map of the HCP Terraform projects with their 'id' as the only key. Currently, this only supports the 'Default Project' project. |
+| <a name="output_tfe_project_variable_set"></a> [tfe\_project\_variable\_set](#output\_tfe\_project\_variable\_set) | A map of variable set and project pairs. |
 | <a name="output_tfe_team"></a> [tfe\_team](#output\_tfe\_team) | A map of the HCP Terraform teams with their 'id' and the members represented as `organization_membership_ids`. Currently, this only supports the 'owners' team. |
 | <a name="output_tfe_variable_set"></a> [tfe\_variable\_set](#output\_tfe\_variable\_set) | A map of variable sets and their details as configured in the HCP Terraform organization. |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -44,4 +44,21 @@ locals {
       }
     )
   }
+
+  # Expand each variable set into a variable set and project pair.
+  variable_set_project_pairs = flatten([
+    for variable_set_id, variable_set in local.variable_sets : [
+      for project_id in variable_set.project_ids : {
+        variable_set_id = variable_set_id
+        project_id      = project_id
+      }
+    ]
+  ])
+
+  # Create a map of variable set and project pairs to align with
+  # the `tfe_project_variable_set` resource.
+  project_variable_sets = {
+    for pair in local.variable_set_project_pairs :
+    "${pair.variable_set_id}_${pair.project_id}" => pair
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -46,11 +46,12 @@ locals {
   }
 
   # Expand each variable set into a variable set and project pair.
-  variable_set_project_pairs = flatten([
+  project_variable_set_pairs = flatten([
     for variable_set_id, variable_set in local.variable_sets : [
       for project_id in variable_set.project_ids : {
-        variable_set_id = variable_set_id
-        project_id      = project_id
+        variable_set_name = variable_set.name
+        variable_set_id   = variable_set_id
+        project_id        = project_id
       }
     ]
   ])
@@ -58,7 +59,7 @@ locals {
   # Create a map of variable set and project pairs to align with
   # the `tfe_project_variable_set` resource.
   project_variable_sets = {
-    for pair in local.variable_set_project_pairs :
+    for pair in local.project_variable_set_pairs :
     "${pair.variable_set_id}_${pair.project_id}" => pair
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "tfe_variable_set" {
   value       = local.variable_sets
   description = "A map of variable sets and their details as configured in the HCP Terraform organization."
 }
+
+output "tfe_project_variable_set" {
+  value       = local.project_variable_sets
+  description = "A map of variable set and project pairs."
+}


### PR DESCRIPTION
Adding the `tfe_project_variable_set` output which is a map of `variable_set_id`/`project_id` pairs that can be iterated over to import projects and variable set associations.

This includes the `variable_set_name` since that is the attribute used to import the resource.