### PR TITLE
feat: Add tfe_workspace discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ No inputs.
 | [tfe_team.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/team) | data source |
 | [tfe_variable_set.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/variable_set) | data source |
 | [tfe_variables.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/variables) | data source |
+| [tfe_workspace.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/workspace) | data source |
+| [tfe_workspace_ids.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/workspace_ids) | data source |
 
 ## Outputs
 
@@ -216,6 +218,7 @@ No inputs.
 | <a name="output_tfe_project_variable_set"></a> [tfe\_project\_variable\_set](#output\_tfe\_project\_variable\_set) | A map of variable set and project pairs. |
 | <a name="output_tfe_team"></a> [tfe\_team](#output\_tfe\_team) | A map of the HCP Terraform teams with their 'id' and the members represented as `organization_membership_ids`. Currently, this only supports the 'owners' team. |
 | <a name="output_tfe_variable_set"></a> [tfe\_variable\_set](#output\_tfe\_variable\_set) | A map of variable sets and their details as configured in the HCP Terraform organization. |
+| <a name="output_tfe_workspace"></a> [tfe\_workspace](#output\_tfe\_workspace) | A map of workspaces and their details as configured in the HCP Terraform organization. |
 <!-- END_TF_DOCS -->
 
 ## Manual Onboarding Setup

--- a/discovery.tf
+++ b/discovery.tf
@@ -18,3 +18,15 @@ data "tfe_variables" "this" {
   for_each        = local.variable_set_names
   variable_set_id = data.tfe_variable_set.this[each.key].id
 }
+
+data "tfe_workspace_ids" "this" {
+  names        = ["*"]
+  organization = data.tfe_organization.this.name
+}
+
+data "tfe_workspace" "this" {
+  for_each = toset([for name, id in data.tfe_workspace_ids.this.ids : name])
+
+  name         = each.key
+  organization = data.tfe_organization.this.name
+}

--- a/locals.tf
+++ b/locals.tf
@@ -62,4 +62,11 @@ locals {
     for pair in local.project_variable_set_pairs :
     "${pair.variable_set_id}_${pair.project_id}" => pair
   }
+
+  # Use the workspace ID as the keys in the map to align with
+  # other resources being iterated over.
+  workspaces = {
+    for name, workspace in data.tfe_workspace.this :
+    workspace.id => workspace
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,3 +42,8 @@ output "tfe_project_variable_set" {
   value       = local.project_variable_sets
   description = "A map of variable set and project pairs."
 }
+
+output "tfe_workspace" {
+  value       = local.workspaces
+  description = "A map of workspaces and their details as configured in the HCP Terraform organization."
+}


### PR DESCRIPTION
Adding the `tfe_workspace` output which is a map of `workspace_ids` with their configuration that can be iterated over to import workspaces.

This output isn't as generic as I would like it, for example you would need to conditionally set the resource configuration based on the returned configuration (`vcs_repo` could be populated or not). An additional output will be added in the future to make this easier for consumers. 
