### PR TITLE
fix: Add version constraints to the providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ import {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.7 |
-| <a name="requirement_external"></a> [external](#requirement\_external) | 2.3.5 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | 0.71.0 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.44.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.71.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | >= 2.3.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.44.0 |
 
 ## Inputs
 
@@ -132,18 +132,18 @@ No inputs.
 
 | Name | Type |
 |------|------|
-| [external_external.owners_team_emails](https://registry.terraform.io/providers/hashicorp/external/2.3.5/docs/data-sources/external) | data source |
-| [external_external.variable_set_names](https://registry.terraform.io/providers/hashicorp/external/2.3.5/docs/data-sources/external) | data source |
-| [tfe_organization.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/organization) | data source |
-| [tfe_organization_members.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/organization_members) | data source |
-| [tfe_organization_membership.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/organization_membership) | data source |
-| [tfe_organizations.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/organizations) | data source |
-| [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/project) | data source |
-| [tfe_team.owners](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/team) | data source |
-| [tfe_variable_set.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/variable_set) | data source |
-| [tfe_variables.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/variables) | data source |
-| [tfe_workspace.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/workspace) | data source |
-| [tfe_workspace_ids.this](https://registry.terraform.io/providers/hashicorp/tfe/0.71.0/docs/data-sources/workspace_ids) | data source |
+| [external_external.owners_team_emails](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [external_external.variable_set_names](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [tfe_organization.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/organization) | data source |
+| [tfe_organization_members.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/organization_members) | data source |
+| [tfe_organization_membership.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/organization_membership) | data source |
+| [tfe_organizations.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/organizations) | data source |
+| [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/project) | data source |
+| [tfe_team.owners](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/team) | data source |
+| [tfe_variable_set.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/variable_set) | data source |
+| [tfe_variables.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/variables) | data source |
+| [tfe_workspace.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/workspace) | data source |
+| [tfe_workspace_ids.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/workspace_ids) | data source |
 
 ## Outputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = ">= 0.44.0"
     }
     external = {
       source  = "hashicorp/external"
-      version = "2.3.5"
+      version = ">= 2.3.0"
     }
   }
 }


### PR DESCRIPTION
By not having version constraints (as opposed to pinning provider versions) in a module, it can force a provider upgrade (and lockfile change) or cause an `init` failure to downstream consumers.

I have looked through previous versions of each provider and determined which version is the earliest possible version that could be used with this module.