### PR TITLE
fix: Correct version constraint after testing earlier versions of the `tfe` provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = "~> 0.71"
     }
   }
 }
@@ -38,7 +38,7 @@ terraform {
 # TFE_TOKEN environment variable in the Terraform run environment.
 module "discovery" {
   source  = "craigsloggett/discovery/tfe"
-  version = "0.14.1"
+  version = "0.14.3"
 }
 
 # The following are the resources that come with every new HCP Terraform organization.
@@ -115,14 +115,14 @@ import {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.7 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.44.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.71.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_external"></a> [external](#provider\_external) | >= 2.3.0 |
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.44.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.71.0 |
 
 ## Inputs
 

--- a/examples/imports/.terraform.lock.hcl
+++ b/examples/imports/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.3.5"
+  constraints = ">= 2.3.0"
+  hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tfe" {
+  version     = "0.70.0"
+  constraints = ">= 0.44.0, 0.70.0"
+  hashes = [
+    "h1:Ec0oVc+y+v0D3X/xw36RgPqNJHF7gTTllgoAJFUY73Y=",
+    "zh:15da83e255cb314c3a6dc4dee116bde408a19f91fed09ca9b57421ff18e825f2",
+    "zh:1893ea8d8af605cf89c23b16df2a91c0e1b35de97fcd2a5f3f4ffec01f78bbae",
+    "zh:22b998a850219a3e27205771b9827ed093c904a422dcba37301c1b42a73b17fa",
+    "zh:23654e8da805856609198a711510e398a185c9fc6ecd538ed21fbf18f38dab55",
+    "zh:4f40c6376359ea09fb359a935bab22e44d2cdade81abba0935117f429736bbd5",
+    "zh:53baf684acaf80d16fa8a34a2a6d12ec3449e12c593e95f34df451b52475a0a3",
+    "zh:541d4532c875b2ee7ecb98da9a1461e76788893b623b0adf7c634d9fff7770e3",
+    "zh:625a4dea24f33700b5c11a27447c3227401490f0ad005c3e28825c4aa0013f44",
+    "zh:876a21f4691a8bd29ad579e880efeecd916d40e29f3cc5ce5099ecf6540d0c07",
+    "zh:8bd3cdf321db5d8cfa03ba2afbb1a31c2073a06e0d5258fd863974e8ac6918c0",
+    "zh:b063c4d4e5a681411f88afa5c4fe32d9de380c67c3d6cdd5f21ce9de0d4f9f31",
+    "zh:f360c24951e3c102a1106e9912e5ef255a5efa74b44ef37d2251db58d50f2e76",
+  ]
+}

--- a/examples/imports/main.tf
+++ b/examples/imports/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = "~> 0.71"
     }
   }
 }
@@ -19,7 +19,7 @@ terraform {
 # TFE_TOKEN environment variable in the Terraform run environment.
 module "discovery" {
   source  = "craigsloggett/discovery/tfe"
-  version = "0.14.1"
+  version = "0.14.3"
 }
 
 # The following are the resources that come with every new HCP Terraform organization.

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = ">= 0.44.0"
+      version = ">= 0.71.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "~> 1.7"
 
+  # Version 0.71.0 of the `tfe` provider removed service accounts from the
+  # tfe_team_organization_members resource. This module has been written
+  # to match this behaviour when discovering members of the owners team:
+  # https://github.com/hashicorp/terraform-provider-tfe/commit/51c13cc01424fad0d7521022f248c4d3484c0c6f
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = "~> 1.7"
 
-  # Version 0.71.0 of the `tfe` provider removed service accounts from the
-  # tfe_team_organization_members resource. This module has been written
-  # to match this behaviour when discovering members of the owners team:
-  # https://github.com/hashicorp/terraform-provider-tfe/commit/51c13cc01424fad0d7521022f248c4d3484c0c6f
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"


### PR DESCRIPTION
Version 0.71.0 of the `tfe` provider removed service accounts from the tfe_team_organization_members resource. This module has been written to match this behaviour when discovering members of the owners team:

https://github.com/hashicorp/terraform-provider-tfe/commit/51c13cc01424fad0d7521022f248c4d3484c0c6f