### PR TITLE
chore: Align scaffolding with terraform-module-template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,28 @@
 version: 2
 
+# Use this if you are referencing modules from a private module registry.
+# registries:
+#   hcp-terraform:
+#     type: terraform-registry
+#     url: https://app.terraform.io
+#     token: ${{ secrets.TF_TOKEN_APP_TERRAFORM_IO }}
+#
+# If you add the private module registry configuration above, you must add
+# the `registries: '*'` configuration under the `terraform`
+# package-ecosystem configuration below.
+
 updates:
   - package-ecosystem: terraform
-    directory: /
+    directories:
+      - examples/**/*
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(docs)
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(ci)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Lint YAML Files
         uses: craigsloggett/lint-yaml@747f85f46ec4711f7cb87e031f635e12e7310c98 # v1.0.21
 
+  shellcheck:
+    name: Shell
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Lint Shell Scripts
+        uses: craigsloggett/lint-shell@92d33c5528427fc13f2883aff90cb7439e3cb56d # v1.0.1
+
   terraform:
     name: Terraform
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@
 *.tfstate.*
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -28,3 +28,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore the dependency lock file; modules leave provider selection to consumers
+*.terraform.lock.hcl

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -26,6 +26,6 @@ rule "terraform_naming_convention" {
 plugin "terraform" {
   enabled = true
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
-  version = "0.13.0"
+  version = "0.14.1"
   preset  = "all"
 }

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,7 @@
 extends: relaxed
 
+ignore-from-file: .gitignore
+
 rules:
   comments:
     level: error
@@ -25,6 +27,7 @@ rules:
   indentation:
     level: error
     spaces: 2
+    indent-sequences: true
 
   quoted-strings:
     quote-type: single


### PR DESCRIPTION
- Dependabot → template shape: terraform updates scoped to `examples/**/*` with `chore(docs)`, github-actions `chore(ci)`, commented private-registry block
- Adds a shellcheck job to the lint workflow
- yamllint gains `indent-sequences`/`ignore-from-file` where missing
- `.gitignore`: trailing whitespace stripped, `*.terraform.lock.hcl` ignored
- tflint terraform ruleset bumped to 0.14.1 where stale